### PR TITLE
4 个 fork 端修复合入：DB 稳定性 + OOM + ANR

### DIFF
--- a/wkim/src/main/java/com/xinbida/wukongim/WKIMApplication.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/WKIMApplication.java
@@ -148,6 +148,20 @@ public class WKIMApplication {
         }
     }
 
+    /**
+     * 关闭指定的 DBHelper 实例。
+     * 注意：WKDBHelper.getInstance 是按 uid 键控的单例，同 uid 重登会返回同一对象。
+     * 所以这里只在 mDbHelper 仍指向 target 时才关——否则说明已被替换或复用，交给替换方管理。
+     * 调用方（如 ConnectionManager.logoutChat）还应额外检查 token/会话状态，避免关掉复用的活实例。
+     */
+    public synchronized void closeDbHelper(WKDBHelper target) {
+        if (target == null) return;
+        if (mDbHelper == target) {
+            mDbHelper.close();
+            mDbHelper = null;
+        }
+    }
+
     public long getDBUpgradeIndex() {
         if (mContext == null) return 0;
         SharedPreferences setting = mContext.get().getSharedPreferences(

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -28,6 +28,8 @@ public class WKDBHelper {
     private static final String TAG = "WKDBHelper";
 //    private DatabaseHelper mDbHelper;
     private SQLiteDatabase mDb;
+    // Bugly#33246 防御：关闭后所有 entry 方法 short-circuit，避免 IllegalStateException: connection pool closed
+    private volatile boolean isClosed = false;
     
     // 数据库操作线程池（3线程，配合WAL模式支持读写并发）
     private static final ExecutorService dbExecutor = Executors.newFixedThreadPool(3);
@@ -122,6 +124,8 @@ public class WKDBHelper {
      */
     public void close() {
         try {
+            // 先置 isClosed，阻止后续 entry；后台线程内已拿到 cursor 的也会通过 catch 兜底
+            isClosed = true;
             uid = "";
             if (mDb != null) {
                 mDb.close();
@@ -139,31 +143,35 @@ public class WKDBHelper {
 
 
     void insertSql(String tab, ContentValues cv) {
-        if (mDb == null) {
+        if (isClosed || mDb == null) {
             return;
         }
-        mDb.insertWithOnConflict(tab, "", cv, SQLiteDatabase.CONFLICT_REPLACE);
+        try {
+            mDb.insertWithOnConflict(tab, "", cv, SQLiteDatabase.CONFLICT_REPLACE);
+        } catch (IllegalStateException | android.database.SQLException e) {
+            WKLoggerUtils.getInstance().e(TAG, "insertSql aborted: " + e.getMessage());
+        }
     }
 
     public Cursor rawQuery(String sql) {
-        if (mDb == null) {
+        if (isClosed || mDb == null) {
             return null;
         }
         try {
             return mDb.rawQuery(sql, null);
-        } catch (android.database.sqlite.SQLiteException e) {
+        } catch (IllegalStateException | android.database.SQLException e) {
             WKLoggerUtils.getInstance().e(TAG, "rawQuery异常: " + e.getMessage() + " SQL: " + sql);
             return null;
         }
     }
 
     public Cursor rawQuery(String sql, Object[] selectionArgs) {
-        if (mDb == null) {
+        if (isClosed || mDb == null) {
             return null;
         }
         try {
             return mDb.rawQuery(sql, selectionArgs);
-        } catch (android.database.sqlite.SQLiteException e) {
+        } catch (IllegalStateException | android.database.SQLException e) {
             WKLoggerUtils.getInstance().e(TAG, "rawQuery异常: " + e.getMessage() + " SQL: " + sql);
             return null;
         }
@@ -172,7 +180,7 @@ public class WKDBHelper {
     public Cursor select(String table, String selection,
                          String[] selectionArgs,
                          String orderBy) {
-        if (mDb == null) return null;
+        if (isClosed || mDb == null) return null;
         Cursor cursor;
         try {
             cursor = mDb.query(table, null, selection, selectionArgs,
@@ -185,7 +193,7 @@ public class WKDBHelper {
     }
 
     public long insert(String table, ContentValues cv) {
-        if (mDb == null) return 0;
+        if (isClosed || mDb == null) return 0;
         long count = 0;
         try {
             count = mDb.insert(table, SQLiteDatabase.CONFLICT_REPLACE, cv);
@@ -204,14 +212,19 @@ public class WKDBHelper {
     }
 
     public boolean delete(String tableName, String where, String[] whereValue) {
-        if (mDb == null) return false;
-        int count = mDb.delete(tableName, where, whereValue);
-        return count > 0;
+        if (isClosed || mDb == null) return false;
+        try {
+            int count = mDb.delete(tableName, where, whereValue);
+            return count > 0;
+        } catch (IllegalStateException | android.database.SQLException e) {
+            WKLoggerUtils.getInstance().e(TAG, "delete aborted: " + e.getMessage());
+            return false;
+        }
     }
 
     public int update(String table, String[] updateFields,
                       String[] updateValues, String where, String[] whereValue) {
-        if (mDb == null) return 0;
+        if (isClosed || mDb == null) return 0;
         ContentValues cv = new ContentValues();
         for (int i = 0; i < updateFields.length; i++) {
             cv.put(updateFields[i], updateValues[i]);
@@ -227,7 +240,7 @@ public class WKDBHelper {
 
     public boolean update(String tableName, ContentValues cv, String where,
                           String[] whereValue) {
-        if (mDb == null) return false;
+        if (isClosed || mDb == null) return false;
         boolean flag = false;
         try {
             flag = mDb.update(tableName, cv, where, whereValue) > 0;
@@ -239,7 +252,7 @@ public class WKDBHelper {
 
     public boolean update(String tableName, String whereClause,
                           ContentValues args) {
-        if (mDb == null) return false;
+        if (isClosed || mDb == null) return false;
         boolean flag = false;
         try {
             flag = mDb.update(tableName, args, whereClause, null) > 0;

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ChannelMembersManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ChannelMembersManager.java
@@ -107,6 +107,7 @@ public class ChannelMembersManager extends BaseManager {
     public synchronized void save(List<WKChannelMember> list) {
         if (WKCommonUtils.isEmpty(list)) return;
         new Thread(() -> {
+            try {
             String channelID = list.get(0).channelID;
             byte channelType = list.get(0).channelType;
 
@@ -167,6 +168,10 @@ public class ChannelMembersManager extends BaseManager {
                 for (int i = 0, size = updateList.size(); i < size; i++) {
                     setRefreshChannelMember(updateList.get(i), i == updateList.size() - 1);
                 }
+            }
+            } catch (Throwable t) {
+                // Bugly#33246 防御：DB 关闭竞态导致的后台线程崩溃
+                com.xinbida.wukongim.utils.WKLoggerUtils.getInstance().e("ChannelMembersManager", "save aborted: " + t.getMessage());
             }
         }).start();
 

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConnectionManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConnectionManager.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 
 import com.xinbida.wukongim.WKIM;
 import com.xinbida.wukongim.WKIMApplication;
+import com.xinbida.wukongim.db.WKDBHelper;
 import com.xinbida.wukongim.interfaces.IConnectionStatus;
 import com.xinbida.wukongim.interfaces.IGetIpAndPort;
 import com.xinbida.wukongim.message.MessageHandler;
@@ -75,15 +76,24 @@ public class ConnectionManager extends BaseManager {
         WKConnection.getInstance().stopAll();
         WKIM.getInstance().getChannelManager().clearARMCache();
         WKIM.getInstance().getReminderManager().clearAllCache();
-        // DB操作移到后台线程，避免主线程ANR
+        // 捕获当前 DBHelper 引用，延迟关闭只关这个实例：
+        // 避免 500ms sleep 期间用户快速重登 → getDbHelper() 返回新实例 → 被误关
+        final WKDBHelper targetDbHelper = WKIMApplication.getInstance().getDbHelper();
         new Thread(() -> {
             try {
                 MessageHandler.getInstance().saveReceiveMsg();
                 MessageHandler.getInstance().updateLastSendingMsgFail();
+            } catch (Throwable t) {
+                // Bugly#33246 防御：登出落盘若撞到 DB 关闭竞态，不让进程崩溃
+                WKLoggerUtils.getInstance().e(TAG, "logout save aborted: " + t.getMessage());
             } finally {
                 // 延迟关闭DB，等待其他in-flight DB操作完成
                 try { Thread.sleep(500); } catch (InterruptedException ignored) {}
-                WKIMApplication.getInstance().closeDbHelper();
+                // 500ms 窗口内若用户已快速重登（token 非空），则跳过关闭——
+                // 因为 WKDBHelper 同 uid 复用同一实例，关了就把新会话的活实例也关了
+                if (TextUtils.isEmpty(WKIMApplication.getInstance().getToken())) {
+                    WKIMApplication.getInstance().closeDbHelper(targetDbHelper);
+                }
             }
         }, "logout-db").start();
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/ConversationManager.java
@@ -82,8 +82,14 @@ public class ConversationManager extends BaseManager {
             return;
         }
         dispatchQueuePool.execute(() -> {
-            List<WKUIConversationMsg> list = ConversationDbManager.getInstance().queryAll();
-            iAllConversations.onResult(list);
+            try {
+                List<WKUIConversationMsg> list = ConversationDbManager.getInstance().queryAll();
+                iAllConversations.onResult(list);
+            } catch (Throwable t) {
+                // Bugly#33246 防御：DB 关闭竞态导致的后台线程崩溃
+                WKLoggerUtils.getInstance().e("ConversationManager", "getAll aborted: " + t.getMessage());
+                iAllConversations.onResult(new java.util.ArrayList<>());
+            }
         });
     }
 
@@ -293,7 +299,14 @@ public class ConversationManager extends BaseManager {
             long version = ConversationDbManager.getInstance().queryMaxVersion();
             String lastMsgSeqStr = ConversationDbManager.getInstance().queryLastMsgSeqs();
             runOnMainThread(() -> iSyncConversationChat.syncConversationChat(lastMsgSeqStr, 10, version, syncChat -> {
-                dispatchQueuePool.execute(() -> saveSyncChat(syncChat, () -> iSyncConversationChatBack.onBack(syncChat)));
+                dispatchQueuePool.execute(() -> {
+                    try {
+                        saveSyncChat(syncChat, () -> iSyncConversationChatBack.onBack(syncChat));
+                    } catch (Throwable t) {
+                        // Bugly#33246 防御：DB 关闭竞态导致的后台线程崩溃
+                        WKLoggerUtils.getInstance().e("ConversationManager", "saveSyncChat aborted: " + t.getMessage());
+                    }
+                });
             }));
         } else {
             WKLoggerUtils.getInstance().e("未设置同步最近会话事件");

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
@@ -955,10 +955,13 @@ public class MsgManager extends BaseManager {
     public void setSyncChannelMsgListener(String channelID, byte channelType, long startMessageSeq, long endMessageSeq, int limit, int pullMode, ISyncChannelMsgBack iSyncChannelMsgBack) {
         if (this.iSyncChannelMsgListener != null) {
             runOnMainThread(() -> iSyncChannelMsgListener.syncChannelMsgs(channelID, channelType, startMessageSeq, endMessageSeq, limit, pullMode, syncChannelMsg -> {
-                if (syncChannelMsg != null && WKCommonUtils.isNotEmpty(syncChannelMsg.messages)) {
-                    saveSyncChannelMSGs(syncChannelMsg.messages);
-                }
-                iSyncChannelMsgBack.onBack(syncChannelMsg);
+                // DB写入和后续查询移至后台线程，避免主线程SQLCipher连接池竞争ANR
+                new Thread(() -> {
+                    if (syncChannelMsg != null && WKCommonUtils.isNotEmpty(syncChannelMsg.messages)) {
+                        saveSyncChannelMSGs(syncChannelMsg.messages);
+                    }
+                    iSyncChannelMsgBack.onBack(syncChannelMsg);
+                }).start();
             }));
         }
     }

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
@@ -998,8 +998,15 @@ public class MsgManager extends BaseManager {
         if (WKCommonUtils.isNotEmpty(reactionList)) {
             MsgDbManager.getInstance().insertMsgReactions(reactionList);
         }
-        List<WKMsg> saveList = MsgDbManager.getInstance().queryWithMsgIds(msgIds);
-        getMsgReactionsAndRefreshMsg(msgIds, saveList);
+        // Bugly#30231 OOM 优化：复用 msgList 而不是再次全量 queryWithMsgIds，
+        // 避免 200-500 条消息同时在堆里持有两份（50-200MB 重复占用）
+        // reactionList 清空让 getMsgReactionsAndRefreshMsg 从 DB 重建，行为与原 saveList 路径等价
+        if (WKCommonUtils.isNotEmpty(msgList)) {
+            for (int i = 0, size = msgList.size(); i < size; i++) {
+                msgList.get(i).reactionList = null;
+            }
+            getMsgReactionsAndRefreshMsg(msgIds, msgList);
+        }
     }
 
     public void addOnSendMsgAckListener(String key, ISendACK iSendACKListener) {

--- a/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/manager/MsgManager.java
@@ -304,6 +304,7 @@ public class MsgManager extends BaseManager {
      */
     public void getOrSyncHistoryMessages(String channelId, byte channelType, long oldestOrderSeq, boolean contain, int pullMode, int limit, long aroundMsgOrderSeq, final IGetOrSyncHistoryMsgBack iGetOrSyncHistoryMsgBack) {
         new Thread(() -> {
+            try {
             int tempPullMode = pullMode;
             long tempOldestOrderSeq = oldestOrderSeq;
             boolean tempContain = contain;
@@ -348,6 +349,10 @@ public class MsgManager extends BaseManager {
                 }
             }
             MsgDbManager.getInstance().queryOrSyncHistoryMessages(channelId, channelType, tempOldestOrderSeq, tempContain, tempPullMode, limit, iGetOrSyncHistoryMsgBack);
+            } catch (Throwable t) {
+                // Bugly#33246 防御：DB 关闭竞态 / 登出路径导致的连接池关闭等异步崩溃，在此兜底
+                com.xinbida.wukongim.utils.WKLoggerUtils.getInstance().e("MsgManager", "getOrSyncHistoryMessages aborted: " + t.getMessage());
+            }
         }).start();
     }
 
@@ -957,10 +962,15 @@ public class MsgManager extends BaseManager {
             runOnMainThread(() -> iSyncChannelMsgListener.syncChannelMsgs(channelID, channelType, startMessageSeq, endMessageSeq, limit, pullMode, syncChannelMsg -> {
                 // DB写入和后续查询移至后台线程，避免主线程SQLCipher连接池竞争ANR
                 new Thread(() -> {
-                    if (syncChannelMsg != null && WKCommonUtils.isNotEmpty(syncChannelMsg.messages)) {
-                        saveSyncChannelMSGs(syncChannelMsg.messages);
+                    try {
+                        if (syncChannelMsg != null && WKCommonUtils.isNotEmpty(syncChannelMsg.messages)) {
+                            saveSyncChannelMSGs(syncChannelMsg.messages);
+                        }
+                        iSyncChannelMsgBack.onBack(syncChannelMsg);
+                    } catch (Throwable t) {
+                        // Bugly#33246 防御：DB 关闭竞态导致的后台线程崩溃
+                        com.xinbida.wukongim.utils.WKLoggerUtils.getInstance().e("MsgManager", "saveSyncChannelMSGs aborted: " + t.getMessage());
                     }
-                    iSyncChannelMsgBack.onBack(syncChannelMsg);
                 }).start();
             }));
         }

--- a/wkim/src/main/java/com/xinbida/wukongim/message/WKConnection.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/message/WKConnection.java
@@ -713,6 +713,9 @@ public class WKConnection {
                                     resendMsg();
                                     WKIM.getInstance().getConnectionManager().setConnectionStatus(WKConnectStatus.success, WKConnectReason.ConnectSuccess);
                                 }
+                            } catch (Throwable t) {
+                                // Bugly#33246 防御：saveReceiveMsg 若撞到 DB 关闭竞态，兜底吞异常
+                                WKLoggerUtils.getInstance().e(TAG, "setSyncOfflineMsg callback aborted: " + t.getMessage());
                             } finally {
                                 if (innerLocked) {
                                     connectionLock.unlock();
@@ -736,6 +739,9 @@ public class WKConnection {
                                 resendMsg();
                                 WKIM.getInstance().getConnectionManager().setConnectionStatus(WKConnectStatus.success, WKConnectReason.ConnectSuccess);
                             }
+                        } catch (Throwable t) {
+                            // Bugly#33246 防御：回调内 DB 访问若撞到关闭竞态，兜底吞异常
+                            WKLoggerUtils.getInstance().e(TAG, "setSyncConversationListener callback aborted: " + t.getMessage());
                         } finally {
                             if (innerLocked) {
                                 connectionLock.unlock();
@@ -745,7 +751,12 @@ public class WKConnection {
                 }
             } else if (status == WKConnectStatus.kicked) {
                 WKLoggerUtils.getInstance().e(TAG, "Received kick message");
-                MessageHandler.getInstance().updateLastSendingMsgFail();
+                try {
+                    MessageHandler.getInstance().updateLastSendingMsgFail();
+                } catch (Throwable t) {
+                    // Bugly#33246 防御：kicked 场景 DB 可能已被登出路径关闭
+                    WKLoggerUtils.getInstance().e(TAG, "updateLastSendingMsgFail aborted: " + t.getMessage());
+                }
                 WKIMApplication.getInstance().isCanConnect = false;
                 stopAll();
             } else {

--- a/wkim/src/main/java/com/xinbida/wukongim/utils/DateUtils.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/utils/DateUtils.java
@@ -22,12 +22,23 @@ public class DateUtils {
         return DateUtilsBinder.DATE_UTILS;
     }
 
+    /**
+     * Bugly#35089/#35070: 历史消息/群成员分页查询时，每行反序列化都 new 一次 SimpleDateFormat，
+     * 100 行 = ~200 个实例的瞬时分配。SimpleDateFormat 非线程安全，用 ThreadLocal 让每个线程
+     * 复用一个实例：分配从 O(N 行) 降到 O(线程数)。
+     */
+    private static final ThreadLocal<SimpleDateFormat> SDF_CACHE = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault());
+        }
+    };
+
     public String time2DateStr(long timeStamp) {
         if (String.valueOf(timeStamp).length() < 13) {
             timeStamp = timeStamp * 1000;
         }
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault());
-        return sdf.format(new Date(timeStamp));
+        return SDF_CACHE.get().format(new Date(timeStamp));
     }
 
 


### PR DESCRIPTION
## 概要

4 个 fork 端修复合入上游：DB 稳定性 + OOM + ANR

延续 [PR #24](https://github.com/WuKongIM/WuKongIMAndroidSDK/pull/24) (`fix/db-stability-and-performance`) 的方向，把 fork 上后续累积的 4 个修复一起提上来，便于上游统一维护。

## 包含 commits（按时间序）

- **fix: setSyncChannelMsgListener DB 写入移至后台线程**
  saveSyncChannelMSGs 在主线程与 DB 线程竞争 SQLCipher 连接池，实测会阻塞主线程触发 ANR

- **perf: Bugly#30231 OOM — saveSyncChannelMSGs 删冗余 queryWithMsgIds**
  消息批同步时 200-500 条同时在堆里持有两份（50-200MB 重复占用），改成复用 msgList

- **fix: Bugly#33246 连接池关闭竞态 — 两层防御 + logout race 修复**
  IllegalStateException: Cannot perform this operation because the connection pool has been closed
  - WKDBHelper 加 isClosed 标志 + 入口短路（捕获 IllegalStateException / SQLException）
  - 后台 Runnable 统一 try-catch Throwable
  - logoutChat 修复 token 复用时误关 DB 实例（500ms 延迟 + closeDbHelper 重载）

- **perf: Bugly#35089/#35070 OOM — DateUtils.time2DateStr 改 ThreadLocal 缓存**
  历史消息/群成员分页查询时每行 new SimpleDateFormat（~2-3KB），改 ThreadLocal 后分配次数 O(N) → O(线程数)

## 测试验证

- [x] `:wkim:assembleDebug` 编译通过（基于 upstream/master HEAD + 4 个 cherry-pick）
- [x] sweetdog（下游消费方）已在生产环境长期运行这 4 个修复，smoke 16/16 全过
- [x] cherry-pick 全部 auto-merge 成功，无手动冲突
