### PR TITLE
补 PR #25 漏覆盖：cursor 消费 IllegalStateException 兜底

### DIFF
--- a/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/ConversationDbManager.java
@@ -91,7 +91,7 @@ public class ConversationDbManager {
                 return list;
             }
             List<String> clientMsgNos = new ArrayList<>();
-            for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
+            for (WKDBHelper.safeMoveToFirst(cursor); !WKDBHelper.safeIsAfterLast(cursor); WKDBHelper.safeMoveToNext(cursor)) {
                 WKConversationMsg msg = serializeMsg(cursor);
                 if (msg.isDeleted == 0) {
                     WKUIConversationMsg uiMsg = getUIMsg(msg, cursor);
@@ -190,7 +190,7 @@ public class ConversationDbManager {
                 return list;
             }
 
-            for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
+            for (WKDBHelper.safeMoveToFirst(cursor); !WKDBHelper.safeIsAfterLast(cursor); WKDBHelper.safeMoveToNext(cursor)) {
                 WKConversationMsg msg = serializeMsg(cursor);
                 WKUIConversationMsg uiMsg = getUIMsg(msg, cursor);
                 list.add(uiMsg);
@@ -210,7 +210,7 @@ public class ConversationDbManager {
                 return list;
             }
 
-            for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
+            for (WKDBHelper.safeMoveToFirst(cursor); !WKDBHelper.safeIsAfterLast(cursor); WKDBHelper.safeMoveToNext(cursor)) {
                 WKConversationMsg msg = serializeMsg(cursor);
                 list.add(msg);
             }
@@ -246,7 +246,7 @@ public class ConversationDbManager {
                 .getDbHelper()
                 .rawQuery(sql);
         if (cursor != null) {
-            if (cursor.moveToFirst()) {
+            if (WKDBHelper.safeMoveToFirst(cursor)) {
                 maxVersion = WKCursor.readLong(cursor, WKDBColumns.WKCoverMessageColumns.version);
             }
             cursor.close();
@@ -269,7 +269,7 @@ public class ConversationDbManager {
         if (cursor == null) {
             return lastMsgSeqs;
         }
-        if (cursor.moveToFirst()) {
+        if (WKDBHelper.safeMoveToFirst(cursor)) {
             lastMsgSeqs = WKCursor.readString(cursor, "synckey");
         }
         cursor.close();
@@ -310,7 +310,7 @@ public class ConversationDbManager {
                 .rawQuery(sql, new Object[]{channelID, channelType});
         WKConversationMsg conversationMsg = null;
         if (cursor != null) {
-            if (cursor.moveToFirst()) {
+            if (WKDBHelper.safeMoveToFirst(cursor)) {
                 conversationMsg = serializeMsg(cursor);
             }
             cursor.close();
@@ -420,7 +420,7 @@ public class ConversationDbManager {
                 .select(conversation, selection, selectionArgs,
                         null);
         if (cursor != null) {
-            if (cursor.moveToFirst()) {
+            if (WKDBHelper.safeMoveToFirst(cursor)) {
                 msg = serializeMsg(cursor);
             }
             cursor.close();
@@ -441,7 +441,7 @@ public class ConversationDbManager {
                 .getInstance()
                 .getDbHelper().select(conversationExtra, selection, new String[]{channelID, String.valueOf(channelType)}, null);
         if (cursor != null) {
-            if (cursor.moveToFirst()) {
+            if (WKDBHelper.safeMoveToFirst(cursor)) {
                 msgExtra = serializeMsgExtra(cursor);
             }
             cursor.close();
@@ -456,7 +456,7 @@ public class ConversationDbManager {
             if (cursor == null) {
                 return list;
             }
-            for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
+            for (WKDBHelper.safeMoveToFirst(cursor); !WKDBHelper.safeIsAfterLast(cursor); WKDBHelper.safeMoveToNext(cursor)) {
                 WKConversationMsgExtra extra = serializeMsgExtra(cursor);
                 list.add(extra);
             }
@@ -549,7 +549,7 @@ public class ConversationDbManager {
                 .getDbHelper()
                 .rawQuery(sql);
         if (cursor != null) {
-            if (cursor.moveToFirst()) {
+            if (WKDBHelper.safeMoveToFirst(cursor)) {
                 maxVersion = WKCursor.readLong(cursor, "version");
             }
             cursor.close();

--- a/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
+++ b/wkim/src/main/java/com/xinbida/wukongim/db/WKDBHelper.java
@@ -142,6 +142,41 @@ public class WKDBHelper {
     }
 
 
+    /**
+     * Bugly#33446 兜底：cursor.moveToFirst() 在 lazy fillWindow 时向连接池拿 connection，
+     * 若连接池已关（logout race / 切账号），抛 IllegalStateException。
+     * 所有 DbManager 的 cursor 消费点都应改用此 helper（PR #25 1926a14 只覆盖了 rawQuery 入口，
+     * cursor 拿到后离开 WKDBHelper 再 fillWindow 不在防御范围内）。
+     */
+    public static boolean safeMoveToFirst(Cursor cursor) {
+        if (cursor == null) return false;
+        try {
+            return cursor.moveToFirst();
+        } catch (IllegalStateException | android.database.SQLException e) {
+            WKLoggerUtils.getInstance().e(TAG, "safeMoveToFirst aborted: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public static boolean safeMoveToNext(Cursor cursor) {
+        if (cursor == null) return false;
+        try {
+            return cursor.moveToNext();
+        } catch (IllegalStateException | android.database.SQLException e) {
+            WKLoggerUtils.getInstance().e(TAG, "safeMoveToNext aborted: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public static boolean safeIsAfterLast(Cursor cursor) {
+        if (cursor == null) return true;
+        try {
+            return cursor.isAfterLast();
+        } catch (IllegalStateException | android.database.SQLException e) {
+            return true;  // fail-safe，跳出循环
+        }
+    }
+
     void insertSql(String tab, ContentValues cv) {
         if (isClosed || mDb == null) {
             return;


### PR DESCRIPTION
## 概要

补 PR #25 漏覆盖：`cursor.moveToFirst()` 在 lazy fillWindow 时仍向连接池拿 connection，若已关抛 `IllegalStateException`。

PR #25 (commit 1926a14) 在 `WKDBHelper.rawQuery()` 入口加了 isClosed 短路 + try-catch，但返回的 cursor 离开 WKDBHelper 后再 fillWindow 仍在 DbManager 的调用方崩溃。本 PR 在 WKDBHelper 加 3 个 public static helper 统一兜底，ConversationDbManager 10 处 cursor 消费点替换。

## 包含 commit

**fix: Bugly#33446 SQLCipher 连接池关闭后 cursor 消费崩**

变更：
- `WKDBHelper.java` 加 3 个 public static helper：
  - `safeMoveToFirst(Cursor)` / `safeMoveToNext(Cursor)` / `safeIsAfterLast(Cursor)`
  - 内部 try-catch `IllegalStateException` + `android.database.SQLException`
- `ConversationDbManager.java` 10 处 cursor 消费点改用 helper：
  - 6 处 `if (cursor.moveToFirst())` → `if (WKDBHelper.safeMoveToFirst(cursor))`
  - 4 处 `for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext())` → `for (WKDBHelper.safeMoveToFirst(cursor); !WKDBHelper.safeIsAfterLast(cursor); WKDBHelper.safeMoveToNext(cursor))`

典型崩溃路径（fork 端 sweetdog 实测）：
```
ChatActivity.onDestroy → saveEditContent → 后台 Thread → MsgModel.clearUnread
→ ConversationManager.updateRedDot → ConversationDbManager.queryWithChannel:313
→ cursor.moveToFirst() 触发 fillWindow → 连接池已关 → IllegalStateException
```
撞上 logout 500ms 关库窗口必现。

## 测试验证

- [x] `:wkim:assembleDebug` 编译通过（基于 upstream/master HEAD + cherry-pick）
- [x] sweetdog（下游消费方）已部署带此修复的 patch_version=3 推全量中
- [x] cherry-pick 后无冲突（与 a3b4ea0 改 getDb() 在不同位置，3-way merge 干净）

## 后续 sweep（独立 PR）

其他 DbManager（ChatChannelMembersDbManager / MsgDbManager 等）的 cursor 消费点同模式裸调，建议后续单独 PR 全工程统一走 helper。本 PR 仅覆盖触发本次崩溃的 ConversationDbManager。
